### PR TITLE
Process icon assets on both browser action and page action

### DIFF
--- a/dev-env/manifest/processor/action.js
+++ b/dev-env/manifest/processor/action.js
@@ -15,10 +15,10 @@ export default function(manifest, {buildPath}) {
   const scripts = []
 
   // Browser action
-  process({action: browser_action, buildPath, scripts})
+  if(browser_action) process({action: browser_action, buildPath, scripts})
 
   // Page action
-  process({action: page_action, buildPath, scripts})
+  if(page_action) process({action: page_action, buildPath, scripts})
 
-  return {scripts}
+  return { scripts }
 }

--- a/dev-env/manifest/processor/assets.js
+++ b/dev-env/manifest/processor/assets.js
@@ -5,9 +5,9 @@ import mkdirp from 'mkdirp'
 
 import * as paths from '../../paths'
 import * as log from '../log'
-import * as Remove from '../../remove';
+import * as Remove from '../../remove'
 
-const buildAssetsDir = "$assets"
+const buildAssetsDir = '$assets'
 
 const processAsset = function(object, key, buildPath) {
   const assetPath = object[key]
@@ -38,14 +38,36 @@ const processAsset = function(object, key, buildPath) {
   return true
 }
 
-export default function(manifest, {buildPath}) {
+const processIcon = function(action, key, buildPath) {
+  let settings = action[key];
+
+  if(typeof settings === 'object') {
+    _.forEach(settings, (iconPath, name) => processAsset(settings, name, buildPath))
+  } else {
+    processAsset(action, key, buildPath)
+  }
+}
+
+export default function(manifest, { buildPath }) {
+
+  const { browser_action, page_action } = manifest
 
   // Process icons
-  if (manifest.icons && Object.keys(manifest.icons).length) {
-    _.forEach(manifest.icons, (iconPath, name) => processAsset(manifest.icons, name, buildPath))
+  if (manifest.icons) {
+    processIcon(manifest, 'icons', buildPath)
+  }
+
+  // Browser action
+  if(browser_action && browser_action.default_icon) {
+    processIcon(browser_action, 'default_icon', buildPath)
+  }
+
+  // Page action
+  if(page_action && page_action.default_icon) {
+    processIcon(page_action, 'default_icon', buildPath)
   }
 
   // TODO can there be more assets?
 
-  return {manifest}
+  return { manifest }
 }


### PR DESCRIPTION
According to [chrome extension guiding](https://developer.chrome.com/extensions/pageAction), `page_action` or `browser_action` can have property `default_icon` of a string of the icon path or an object of icons with various size.

Add a function `processIcon` to handle that.